### PR TITLE
Changed Christopher Colomb's subtitle

### DIFF
--- a/data/Team.yaml
+++ b/data/Team.yaml
@@ -349,7 +349,7 @@
 -
     name: 'Christopher Colomb'
     nickname: kurisu
-    subtitle: 'NEO Japan Founder'
+    subtitle: 'NeoJP Community Founder'
     role: Translator
     image: christophercolomb.jpg
     github: kurisu1996


### PR DESCRIPTION
Changed from "NEO Japan Founder" to "NeoJP Community Founder". The name was changed, as it was ambiguous. With the change, we hope for it to cause less confusion among people who are unfamiliar with NeoJP Community's work.