### PR TITLE
fix discord link

### DIFF
--- a/data/Resources.yaml
+++ b/data/Resources.yaml
@@ -5,7 +5,7 @@
   icon: "fa-reddit-alien"
 
 - name: "Discord"
-  url: "https://discordapp.com/invite/R8v48YA"
+  url: "https://discordapp.com/invite/b8QNXwD"
   head: "Join"
   subtitle: "Our Discord Channel"
   icon: "fa-discord"


### PR DESCRIPTION
the Discord link was expired or at least not functional. This invite is the same used on neo.org